### PR TITLE
feat: clothesSelectorStore에 add, remove 함수 추가

### DIFF
--- a/src/stores/clothesSelectorStore.ts
+++ b/src/stores/clothesSelectorStore.ts
@@ -3,6 +3,8 @@ import { ClothesInfo } from '../types/type';
 
 interface ClothesSelectorState {
   clothesInfos: ClothesInfo[];
+  addClothesInfo: (clothesInfo: ClothesInfo) => void;
+  removeClothesInfo: (clothesInfo: ClothesInfo) => void;
   setClothesInfos: (clothesInfos: ClothesInfo[]) => void;
   clearClothesInfo: () => void;
 }
@@ -10,7 +12,13 @@ interface ClothesSelectorState {
 const useClothesSelectorStore = create<ClothesSelectorState>()(
   set => ({
     clothesInfos: [],
+    addClothesInfo: (clothesInfo: ClothesInfo) => set((state) =>
+      ({ clothesInfos: [...state.clothesInfos, clothesInfo] })),
+    removeClothesInfo: (clothesInfo: ClothesInfo) => set((state) =>
+      ({ clothesInfos: state.clothesInfos.filter((item) => item != clothesInfo) })),
     setClothesInfos: (clothesInfos: ClothesInfo[]) => set({ clothesInfos: clothesInfos }),
     clearClothesInfo: () => set({ clothesInfos: [] }),
   })
 )
+
+export default useClothesSelectorStore;


### PR DESCRIPTION
- 코디 추천 시 선택한 옷을 저장하는 전역 상태인 ClothesSelectorState에 clothesInfos 배열에서 아이템을 삭제, 추가하는 메소드 추가
- closet/select 페이지나 wish/select 페이지에서 선택 완료 버튼을 눌렀을 때, addClothesInfo가 사용되어야 합니다.