### PR TITLE
fix: 삭제 버튼이 클릭되지 않던 현상 수정

### DIFF
--- a/src/pages/ClosetPage/style.ts
+++ b/src/pages/ClosetPage/style.ts
@@ -27,4 +27,5 @@ export const DeleteButton = styled.div`
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  z-index: 1;
 `;


### PR DESCRIPTION
- 관련 이슈: #84
- 옷장/위시 옷 삭제 버튼이 옷 정보 카드 뒤에 위치해있어 클릭되지 않던 현상을 수정하였습니다.

수정 후 css 요소 위치

<img width="304" alt="image" src="https://github.com/user-attachments/assets/84659cef-b09d-48fd-bd5e-d1dba6f94a2c">